### PR TITLE
Rename isCollapsed to isExpanded

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ You need to wrap a CollapseHeader & a CollapseBody in the Collapse.
 
 | Props Name | Default | Type | Description |
 | :--: | :--: | :--: | :------------------------- |
-| isCollapsed | false | boolean | show the CollapseBody if true |
+| isExpanded | false | boolean | show the CollapseBody if true |
 | disabled | false | boolean | disable the click on the collapse header if true |
-| onToggle | ()=>undefined | Function(isCollapsed:boolean) | onToggle is a function take in input a boolean value that contains the state of the Collapse (if collapsed->true) |
+| onToggle | ()=>undefined | Function(isExpanded:boolean) | onToggle is a function take in input a boolean value that contains the state of the Collapse (if collapsed->true) |
 | handleLongPress | undefined | Function() | handles the onLongPress event when longPressing on the collapseHeader content |
 
-In case you want to use and change the state of the Collapse in the parent, You can use isCollapsed & onToggle as an input & output to synchronise the parent collapse state & the child (Collapse) state. 
+In case you want to use and change the state of the Collapse in the parent, You can use isExpanded & onToggle as an input & output to synchronise the parent collapse state & the child (Collapse) state. 
 
 ***Example of use***
    
@@ -216,7 +216,7 @@ In case you want to use and change the state of the Collapse in the parent, You 
     constructor(props){
 	    super(props);
 	    this.state = {
-	    collapsed:false,//do not show the body by default
+	      expanded: false, //do not show the body by default
 	    }
     }
     render(){
@@ -224,11 +224,11 @@ In case you want to use and change the state of the Collapse in the parent, You 
 	    <View>
 		    <Button 
 			    title={"Click here too"} 
-			    onPress={()=>this.setState({collapsed:!this.state.collapsed})}
+			    onPress={()=>this.setState({expanded: !this.state.expanded})}
 		    />
 	        <Collapse 
-		        isCollapsed={this.state.collapsed} 
-		        onToggle={(isCollapsed)=>this.setState({collapsed:isCollapsed})}>
+		        isExpanded={this.state.expanded} 
+		        onToggle={(isExpanded)=>this.setState({expanded: isExpanded})}>
 	          <CollapseHeader>
 	            <Text>Click here</Text>
 	          </CollapseHeader>

--- a/src/components/AccordionList/index.js
+++ b/src/components/AccordionList/index.js
@@ -63,8 +63,8 @@ const AccordionList = React.forwardRef(
           const isElementExpanded = _keyExtractor(item, index) === selected;
           return (
             <Collapse
-              isCollapsed={isElementExpanded}
-              onToggle={isExpanded => {
+              isExpanded={isElementExpanded}
+              onToggle={(isExpanded) => {
                 const newlySelected = _keyExtractor(item, index);
                 onToggle(newlySelected, index, isExpanded);
                 setSelected(

--- a/src/components/Collapse/collapse.test.js
+++ b/src/components/Collapse/collapse.test.js
@@ -27,7 +27,7 @@ describe('Collapse', () => {
   });
   it('Should match snapshot while collapsed', () => {
     const renderedComponent = create(
-      <Collapse isCollapsed={true}>
+      <Collapse isExpanded={true}>
         <CollapseHeader>click here</CollapseHeader>
         <CollapseBody>Ta da!</CollapseBody>
       </Collapse>,

--- a/src/components/Collapse/index.js
+++ b/src/components/Collapse/index.js
@@ -10,7 +10,7 @@ import CollapseBody from '../CollapseBody';
 const Collapse = React.forwardRef(
   (
     {
-      isCollapsed = false,
+      isExpanded = false,
       disabled = false,
       onToggle = () => undefined,
       handleLongPress = () => undefined,
@@ -19,10 +19,10 @@ const Collapse = React.forwardRef(
     },
     ref,
   ) => {
-    const [show, setShow] = useState(isCollapsed);
+    const [show, setShow] = useState(isExpanded);
     useEffect(() => {
-      setShow(isCollapsed);
-    }, [isCollapsed]);
+      setShow(isExpanded);
+    }, [isExpanded]);
     let header = null;
     let body = null;
     React.Children.forEach(children, child => {


### PR DESCRIPTION
While using this library, I found myself confused because setting `isCollapsed` to true was resulting in the component displaying the body rather than hiding it. I then read the documentation more carefully, and the README in fact says next to `isCollapsed`:  "show the CollapseBody if true" . So it was working as intended, but not working as my intuition would lead me to believe, since the word "collapse" means to hide, or compress. 

So this PR suggests a name change from `isCollapsed` to `isExpanded`, to better describe the intended functionality of the prop. 

All tests passing:

<img width="1022" alt="Screen Shot 2021-02-19 at 9 58 08 AM" src="https://user-images.githubusercontent.com/6894653/108543627-2c60bf00-729a-11eb-947e-963fe14f16fa.png">


