### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "lint": "eslint .",
     "build": "babel src/ --out-dir build --ignore '**/*.test.js'",
     "test": "jest"
-  },
+  }, 
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-native": "^0.61.5"
+    "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1",
+    "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || 1000.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.7",


### PR DESCRIPTION
When you try to install accordion-collapse-react-native using the latest react-native it fails because of a dependency with react 16. The latests app template uses react-17.

this should fix it