### PR TITLE
fix: Could not find a declaration file for module 'accordion-collapse-react-native'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'accordion-collapse-react-native';


### PR DESCRIPTION

## Description

This is an issue that appears in React Native projects with typescript. Just adding an index.d.ts file with the declaration of the module should fix it.
