### PR TITLE
touchableOpacityProps: added touchableOpacityProps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ You need to wrap a CollapseHeader & a CollapseBody in the Collapse.
 | disabled | false | boolean | disable the click on the collapse header if true |
 | onToggle | ()=>undefined | Function(isExpanded:boolean) | onToggle is a function take in input a boolean value that contains the state of the Collapse (if collapsed->true) |
 | handleLongPress | undefined | Function() | handles the onLongPress event when longPressing on the collapseHeader content |
+| touchableOpacityProps | {} | Object | pass additional props to customize TouchableOpacity component
 
 In case you want to use and change the state of the Collapse in the parent, You can use isExpanded & onToggle as an input & output to synchronise the parent collapse state & the child (Collapse) state. 
 

--- a/src/components/Collapse/index.js
+++ b/src/components/Collapse/index.js
@@ -14,6 +14,7 @@ const Collapse = React.forwardRef(
       disabled = false,
       onToggle = () => undefined,
       handleLongPress = () => undefined,
+      touchableOpacityProps = {},
       children,
       ...restProps
     },
@@ -41,6 +42,7 @@ const Collapse = React.forwardRef(
       return (
         <View ref={ref} {...restProps}>
           <TouchableOpacity
+            {...touchableOpacityProps}
             disabled={disabled}
             onPress={() => {
               onToggle(!show);


### PR DESCRIPTION
This pr adds enhancement that Closes #45 :
Added touchableOpacityProps to Collapse component to make TouchableOpacity component customizable

Tested Integration on Android f.e. setting `activeOpacity:1`

```js
 <Collapse
         touchableOpacityProps={{ activeOpacity: 1 }}>
```